### PR TITLE
Set correct cloudFrontDomainName for DLT bucket AllowedOrigins

### DIFF
--- a/source/infrastructure/lib/distributed-load-testing-on-aws-stack.ts
+++ b/source/infrastructure/lib/distributed-load-testing-on-aws-stack.ts
@@ -385,9 +385,15 @@ export class DLTStack extends Stack {
       cloudFrontDefaultCertificate: cloudFrontDefaultCertificate,
     });
 
+    const cloudFrontDomainName = Fn.conditionIf(
+      hasAliases.logicalId,
+      Fn.select(0, cloudFrontAliases.valueAsList),
+      dltConsole.cloudFrontDomainName
+    ).toString();
+
     const dltStorage = new ScenarioTestRunnerStorageConstruct(this, "DLTTestRunnerStorage", {
       s3LogsBucket,
-      cloudFrontDomainName: dltConsole.cloudFrontDomainName,
+      cloudFrontDomainName: cloudFrontDomainName,
       solutionId,
     });
 
@@ -488,11 +494,6 @@ export class DLTStack extends Stack {
       uuid,
     });
 
-    const cloudFrontDomainName = Fn.conditionIf(
-      hasAliases.logicalId,
-      Fn.select(0, cloudFrontAliases.valueAsList),
-      dltConsole.cloudFrontDomainName
-    ).toString();
     const cognitoResources = new CognitoAuthConstruct(this, "DLTCognitoAuth", {
       adminEmail: adminEmail.valueAsString,
       adminName: adminName.valueAsString,

--- a/source/infrastructure/test/__snapshots__/distributed-load-testing-on-aws-stack.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/distributed-load-testing-on-aws-stack.test.ts.snap
@@ -5568,9 +5568,22 @@ exports[`Distributed Load Testing stack test 1`] = `
                     [
                       "https://",
                       {
-                        "Fn::GetAtt": [
-                          "DLTConsoleResourcesDLTCloudFrontToS3CloudFrontDistribution3EF384B4",
-                          "DomainName",
+                        "Fn::If": [
+                          "BoolAliases",
+                          {
+                            "Fn::Select": [
+                              0,
+                              {
+                                "Ref": "CloudFrontAliases",
+                              },
+                            ],
+                          },
+                          {
+                            "Fn::GetAtt": [
+                              "DLTConsoleResourcesDLTCloudFrontToS3CloudFrontDistribution3EF384B4",
+                              "DomainName",
+                            ],
+                          },
                         ],
                       },
                     ],


### PR DESCRIPTION
DLT bucket AllowedOrigins needs Custom Cloudfront domainname to allow uploading files via web UI.